### PR TITLE
Minor README fix on the import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dive into the world of Python-based structured extraction, by OpenAI's function 
 ## Usage
 
 ```ts
-import Instructor from "@/instructor"
+import Instructor from "@instructor-ai/instructor";
 import OpenAI from "openai"
 import { z } from "zod"
 


### PR DESCRIPTION
I started kicking the tires this evening and noticed that the README had an invalid import, when using instructor installed via npm.