### PR TITLE
fix: updated Pydantic model in JS docs to Zod schema

### DIFF
--- a/docs/blog/posts/anyscale.md
+++ b/docs/blog/posts/anyscale.md
@@ -19,7 +19,7 @@ By the end of this blog post, you will learn how to effectively utilize instruct
 
 Instructor's patch enhances a openai api it with the following features, you can learn more about them [here](../../concepts/modes.md), for anyscale they support `JSON_SCHEMA` and `FUNCTIONS` modes. and with instructor we'll be able to use the following features:
 
-- `response_model` in `create` calls that returns a pydantic model
+- `response_model` in `create` calls that returns a Zod schema
 - `max_retries` in `create` calls that retries the call if it fails by using a backoff strategy
 
 ## Anyscale

--- a/docs/examples/classification.md
+++ b/docs/examples/classification.md
@@ -10,7 +10,7 @@ This tutorial showcases how to implement text classification tasks—specificall
 
 ### Defining the Structures
 
-For single-label classification, we first define an **`enum`** for possible labels and a Pydantic model for the output.
+For single-label classification, we first define an **`enum`** for possible labels and a Zod schema for the output.
 
 ```ts
 import Instructor from "@/instructor"
@@ -68,7 +68,7 @@ console.log({ classification })
 
 ### Defining the Structures
 
-For multi-label classification, we introduce a new enum class and a different Pydantic model to handle multiple labels.
+For multi-label classification, we introduce a new enum class and a different Zod schema to handle multiple labels.
 
 ```ts
 enum MULTI_CLASSIFICATION_LABELS {

--- a/docs/examples/query_decomposition.md
+++ b/docs/examples/query_decomposition.md
@@ -40,7 +40,7 @@ const QueryPlanSchema = z.object({
 
 !!! warning "Graph Generation"
 
-    Notice that this example produces a flat list of items with dependencies that resemble a graph, while pydantic allows for recursive definitions, it's much easier and less confusing for the model to generate flat schemas rather than recursive schemas. If you want to see a recursive example, see [recursive schemas](recursive.md)
+    Notice that this example produces a flat list of items with dependencies that resemble a graph, while Zod allows for recursive definitions, it's much easier and less confusing for the model to generate flat schemas rather than recursive schemas. If you want to see a recursive example, see [recursive schemas](recursive.md)
 
 ## Planning a Query Plan
 
@@ -126,4 +126,4 @@ In the above code, we define a `createQueryPlan` function that takes a question 
 
 ## Conclusion
 
-In this example, we demonstrated how to use the OpenAI Function Call `ChatCompletion` model to plan and execute a query plan using a question-answering system. We defined the necessary structures using Pydantic and created a query planner function.
+In this example, we demonstrated how to use the OpenAI Function Call `ChatCompletion` model to plan and execute a query plan using a question-answering system. We defined the necessary structures using Zod and created a query planner function.


### PR DESCRIPTION
Fixing typos in JS docs. Updating `Pydantic model` to `Zod schema`