### PR TITLE
add example code block

### DIFF
--- a/docs/examples/self_correction.md
+++ b/docs/examples/self_correction.md
@@ -127,10 +127,29 @@ Now, we throw validation error that its objectionable and provide a helpful erro
 
 ## Retrying with Corrections
 
-By adding the `max_retries` parameter, we can retry the request with corrections. and use the error message to correct the output.
+By adding the `max_retries` parameter, we can retry the request with corrections and use the error message to correct the output.
 
 ```ts
-
+try {
+  await instructor.chat.completions.create({
+    model: "gpt-4",
+    max_retries: 2,
+    response_model: { schema: QuestionAnswer, name: "Question and Answer" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are a system that answers questions based on the context. answer exactly what the question asks using the context."
+      },
+      {
+        role: "user",
+        content: `using the context: ${context}\n\nAnswer the following question: ${question}`
+      }
+    ]
+  })
+} catch (e as ZodError[]) {
+  console.error(e[0].message)
+}
 ```
 
 ### Final Output


### PR DESCRIPTION
Added code block for self correction example where max_retries=2. 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 59e32495df2ab16b07869370629e777d3e8b0788.  | 
|--------|--------|

### Summary:
This PR adds a code block to `self_correction.md` demonstrating the use of `max_retries` parameter in `instructor.chat.completions.create` function and error handling with a try-catch block.

**Key points**:
- Added a code block to `self_correction.md` in `docs/examples`.
- The code block demonstrates the use of `max_retries` parameter in `instructor.chat.completions.create` function.
- Included a try-catch block to handle `ZodError`.
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
