### PR TITLE
Add name to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const client = Instructor({
 const user = await client.chat.completions.create({
   messages: [{ role: "user", content: "Jason Liu is 30 years old" }],
   model: "gpt-3.5-turbo",
-  response_model: { schema: UserSchema }
+  response_model: { schema: UserSchema, name: "User" }
 })
 
 console.log(user)


### PR DESCRIPTION
Without a `name`, this fails to compile with:

```
No overload matches this call.
  The last overload gave the following error.
    Property 'name' is missing in type '{ schema: z.ZodObject<{ age: z.ZodNumber; name: z.ZodString; }, "strip", z.ZodTypeAny, { age: number; name: string; }, { age: number; name: string; }>; }' but required in type 'ResponseModel<AnyZodObject>'.ts(2769)

```

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7a46df27d4562929405dfa09ac4025be44ec3e74.  | 
|--------|--------|

### Summary:
This PR fixes a compilation error in the `README.md` example by adding a `name` property to the `response_model` object.

**Key points**:
- Added `name` property to `response_model` object in `README.md` example
- Prevents a compilation error due to missing `name` property in `ResponseModel<AnyZodObject>` type
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
