### PR TITLE
docs(streaming): remove max_retries parameter from function call

### DIFF
--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -66,7 +66,6 @@ const extractionStream = await client.chat.completions.create({
     schema: ExtractionValuesSchema,
     name: "value extraction"
   },
-  max_retries: 3,
   stream: true,
   seed: 1
 })


### PR DESCRIPTION
Is this even allowed? Do we have a defined pattern on what we want to do? 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 788d6118f7d2fb4f2e556bc0eaa7687c687cd037.  | 
|--------|--------|

### Summary:
This PR removes the `max_retries` parameter from a function call in the streaming concepts documentation.

**Key points**:
- Removed `max_retries` parameter from `client.chat.completions.create` function call in `/docs/concepts/streaming.md`
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
