### PR TITLE
chore(exports): export OAIExtended type

### DIFF
--- a/src/dsl/maybe.ts
+++ b/src/dsl/maybe.ts
@@ -7,7 +7,7 @@ export type Maybe<T extends z.ZodTypeAny> = z.ZodObject<{
 }>
 
 /**
- * Create a Maybe model for a given Zod schema. This allows you to return a model that includes fields for `result`, `error`, and `message` for sitatations where the data may not be present in the context.
+ * Create a Maybe model for a given Zod schema. This allows you to return a model that includes fields for `result`, `error`, and `message` for situations where the data may not be present in the context.
  * @param schema The Zod schema to wrap with maybe.
  * @returns A Zod schema that includes fields for `result`, `error`, and `message`.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-import Instructor from "./instructor"
+import Instructor, { OAIClientExtended } from "./instructor"
 
+export { type OAIClientExtended }
 export default Instructor


### PR DESCRIPTION
I'd like to use `LLMValidator` and `maybe`. Because of the way the project is packaged it needs to be exported to the top level. There are also situations using Instructor where having its type exported is super helpful. 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 070f1ea305248d5fe80b8c035c64b5d0352b4be2.  | 
|--------|--------|

### Summary:
This PR exports `LLMValidator`, `maybe`, `Maybe`, and `OAIClientExtended` from the top level and corrects a typo in the `maybe` function comment.

**Key points**:
- Added exports for `LLMValidator`, `maybe`, `Maybe`, and `OAIClientExtended` in `/src/index.ts` and `/src/dsl/index.ts`.
- Corrected a typo in the comment of the `maybe` function in `/src/dsl/maybe.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
