### PR TITLE
adding provider specific transformers + better logging + fixing anyscale

### DIFF
--- a/.changeset/stupid-ducks-act.md
+++ b/.changeset/stupid-ducks-act.md
@@ -1,0 +1,5 @@
+---
+"@instructor-ai/instructor": minor
+---
+
+adding meta to standard completions as well and including usage - also added more verbose debug logs and new provider specific transformers to handle discrepencies in various apis

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -29,7 +29,7 @@ export const NON_OAI_PROVIDER_URLS = {
 
 export const PROVIDER_PARAMS_TRANSFORMERS = {
   [PROVIDERS.ANYSCALE]: {
-    [MODE.JSON_SCHEMA]: function removeAdditionalPropertiesKey<
+    [MODE.JSON_SCHEMA]: function removeAdditionalPropertiesKeyJSONSchema<
       T extends z.AnyZodObject,
       P extends OpenAI.ChatCompletionCreateParams
     >(params: ReturnType<typeof withResponseModel<T, "JSON_SCHEMA", P>>) {
@@ -45,7 +45,7 @@ export const PROVIDER_PARAMS_TRANSFORMERS = {
 
       return params
     },
-    [MODE.TOOLS]: function removeAdditionalPropertiesKey<
+    [MODE.TOOLS]: function removeAdditionalPropertiesKeyTools<
       T extends z.AnyZodObject,
       P extends OpenAI.ChatCompletionCreateParams
     >(params: ReturnType<typeof withResponseModel<T, "TOOLS", P>>) {

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -1,4 +1,7 @@
-import { MODE, type Mode } from "zod-stream"
+import { omit } from "@/lib"
+import OpenAI from "openai"
+import { z } from "zod"
+import { MODE, withResponseModel, type Mode } from "zod-stream"
 
 export const PROVIDERS = {
   OAI: "OAI",
@@ -22,6 +25,52 @@ export const NON_OAI_PROVIDER_URLS = {
   [PROVIDERS.ANYSCALE]: "api.endpoints.anyscale",
   [PROVIDERS.TOGETHER]: "api.together.xyz",
   [PROVIDERS.OAI]: "api.openai.com"
+} as const
+
+export const PROVIDER_PARAMS_TRANSFORMERS = {
+  [PROVIDERS.ANYSCALE]: {
+    [MODE.JSON_SCHEMA]: function removeAdditionalPropertiesKey<
+      T extends z.AnyZodObject,
+      P extends OpenAI.ChatCompletionCreateParams
+    >(params: ReturnType<typeof withResponseModel<T, "JSON_SCHEMA", P>>) {
+      if ("additionalProperties" in params.response_format.schema) {
+        return {
+          ...params,
+          response_format: {
+            ...params.response_format,
+            schema: omit(["additionalProperties"], params.response_format.schema)
+          }
+        }
+      }
+
+      return params
+    },
+    [MODE.TOOLS]: function removeAdditionalPropertiesKey<
+      T extends z.AnyZodObject,
+      P extends OpenAI.ChatCompletionCreateParams
+    >(params: ReturnType<typeof withResponseModel<T, "TOOLS", P>>) {
+      if (params.tools.some(tool => tool.function?.parameters)) {
+        return {
+          ...params,
+          tools: params.tools.map(tool => {
+            if (tool.function?.parameters) {
+              return {
+                ...tool,
+                function: {
+                  ...tool.function,
+                  parameters: omit(["additionalProperties"], tool.function.parameters)
+                }
+              }
+            }
+
+            return tool
+          })
+        }
+      }
+
+      return params
+    }
+  }
 } as const
 
 export const PROVIDER_SUPPORTED_MODES_BY_MODEL = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import Instructor from "./instructor"
 
+export * from "./types"
 export default Instructor

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,13 +2,15 @@ import OpenAI from "openai"
 import { Stream } from "openai/streaming"
 import { z } from "zod"
 import {
-  CompletionMeta,
+  CompletionMeta as ZCompletionMeta,
   type Mode as ZMode,
   type ResponseModel as ZResponseModel
 } from "zod-stream"
 
 export type LogLevel = "debug" | "info" | "warn" | "error"
-
+export type CompletionMeta = Partial<ZCompletionMeta> & {
+  usage?: OpenAI.CompletionUsage
+}
 export type Mode = ZMode
 export type ResponseModel<T extends z.AnyZodObject> = ZResponseModel<T>
 
@@ -37,7 +39,8 @@ export type ReturnTypeBasedOnParams<P> =
       response_model: ResponseModel<infer T>
     }
   ) ?
-    Promise<AsyncGenerator<Partial<z.infer<T>> & { _meta: CompletionMeta }, void, unknown>>
-  : P extends { response_model: ResponseModel<infer T> } ? Promise<z.infer<T>>
+    Promise<AsyncGenerator<Partial<z.infer<T>> & { _meta?: CompletionMeta }, void, unknown>>
+  : P extends { response_model: ResponseModel<infer T> } ?
+    Promise<z.infer<T> & { _meta?: CompletionMeta }>
   : P extends { stream: true } ? Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
   : OpenAI.Chat.Completions.ChatCompletion

--- a/tests/inference.test.ts
+++ b/tests/inference.test.ts
@@ -7,12 +7,12 @@
 // 6. response_model, no stream, max_retries
 
 import Instructor from "@/instructor"
+import { type CompletionMeta } from "@/types"
 import { describe, expect, test } from "bun:test"
 import OpenAI from "openai"
 import { Stream } from "openai/streaming"
 import { type } from "ts-inference-check"
 import { z } from "zod"
-import { CompletionMeta } from "zod-stream"
 
 describe("Inference Checking", () => {
   const UserSchema = z.object({
@@ -61,7 +61,9 @@ describe("Inference Checking", () => {
       stream: false
     })
 
-    expect(type(user).strictly.is<z.infer<typeof UserSchema>>(true)).toBe(true)
+    expect(
+      type(user).strictly.is<z.infer<typeof UserSchema> & { _meta?: CompletionMeta }>(true)
+    ).toBe(true)
   })
 
   test("response_model, stream", async () => {
@@ -79,7 +81,7 @@ describe("Inference Checking", () => {
           Partial<{
             name: string
             age: number
-          }> & { _meta: CompletionMeta },
+          }> & { _meta?: CompletionMeta },
           void,
           unknown
         >
@@ -103,7 +105,7 @@ describe("Inference Checking", () => {
           Partial<{
             name: string
             age: number
-          }> & { _meta: CompletionMeta },
+          }> & { _meta?: CompletionMeta },
           void,
           unknown
         >
@@ -120,6 +122,8 @@ describe("Inference Checking", () => {
       max_retries: 3
     })
 
-    expect(type(user).strictly.is<z.infer<typeof UserSchema>>(true)).toBe(true)
+    expect(
+      type(user).strictly.is<z.infer<typeof UserSchema> & { _meta?: CompletionMeta }>(true)
+    ).toBe(true)
   })
 })

--- a/tests/mode.test.ts
+++ b/tests/mode.test.ts
@@ -96,8 +96,7 @@ async function extractUser(model: string, mode: Mode, provider: Provider) {
     messages: [{ role: "user", content: "Jason Liu is 30 years old" }],
     model: model,
     response_model: { schema: UserSchema, name: "User" },
-    max_retries: 4,
-    seed: provider === PROVIDERS.OAI ? 1 : undefined
+    max_retries: 4
   })
 
   return user


### PR DESCRIPTION
We were starting to get all sorts of failures on tests for anyscale all of a sudden - not sure what happened but I narrowed it down to:

the zod to json schema conversion adds a totally valid property: additionalProperties on the schema - all providers including oai and together have no issue with this property when it is present (its almost always false and seemingly un needed in most cases) - but anyscale started throwing errors that the json schema was invalid - looking back through some logs I had, this is a new development - not sure why its starting to fail all of a sudden tbh

either way - included in this pr are:

- some more verbose debug and error logs - there is an open issue for this and I needed to do some more logging to figure this one out, so it made sense.
- a new provider transformers map - this allows us to apply specific transformations per provider should we need it -i n this case we do
- transformers for anyscale to remove that additionalProperties key

This approach might also help us add azure support or for other providers whos apis don't match up one to one with OAI



<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit e13ec0bfe66c38c5462fb145438a3abd1454ba70.  | 
|--------|--------|

### Summary:
This PR introduces provider-specific transformers, enhances logging, adds a specific transformer for Anyscale, and the changes are considered minor for the '@instructor-ai/instructor' package.

**Key points**:
- Introduced provider-specific transformers.
- Enhanced logging for better debugging.
- Added a specific transformer for Anyscale to remove the 'additionalProperties' key.
- Changes are considered minor for the '@instructor-ai/instructor' package.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
