### PR TITLE
Publish declaration maps so goto definition works properly

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,8 @@
     "isolatedModules": true,
     "incremental": true,
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
👋

I was trying to use this library a bit and understand the the types/source. It is a bit hard in VSCode because jump to definition takes you to a TS declaration file or a compiled JS file today.

This PR adds the TS compiler option to publish declaration maps which fixes this issue, making developer experience better: https://www.typescriptlang.org/tsconfig#declarationMap

It would maybe be nice to cut a release with these enabled if its not a hassle so they actually get published.