### PR TITLE
Include meta on standard completion

### DIFF
--- a/.changeset/happy-suits-dress.md
+++ b/.changeset/happy-suits-dress.md
@@ -1,0 +1,5 @@
+---
+"@instructor-ai/instructor": patch
+---
+
+make sure we pass through \_meta on non stream completions

--- a/examples/extract_user/index.ts
+++ b/examples/extract_user/index.ts
@@ -29,6 +29,7 @@ const user = await client.chat.completions.create({
 })
 
 console.log(user)
+
 // {
 //  age: 30,
 //  name: "Jason Liu",

--- a/src/instructor.ts
+++ b/src/instructor.ts
@@ -221,7 +221,7 @@ class Instructor<C extends GenericClient | OpenAI> {
           }
         }
 
-        return validation.data
+        return { ...validation.data, _meta: data._meta }
       } catch (error) {
         if (!(error instanceof ZodError)) {
           throw error

--- a/src/instructor.ts
+++ b/src/instructor.ts
@@ -221,7 +221,7 @@ class Instructor<C extends GenericClient | OpenAI> {
           }
         }
 
-        return { ...validation.data, _meta: data._meta }
+        return { ...validation.data, _meta: data?._meta ?? {} }
       } catch (error) {
         if (!(error instanceof ZodError)) {
           throw error

--- a/tests/anthropic.test.ts
+++ b/tests/anthropic.test.ts
@@ -142,7 +142,7 @@ describe("LLMClient Anthropic Provider - mode: MD_JSON", () => {
       }
     })
 
-    expect(completion).toEqual({ name: "Dimitri Kennedy" })
+    expect(omit(["_meta"], completion)).toEqual({ name: "Dimitri Kennedy" })
   })
 
   test("complex schema - streaming", async () => {


### PR DESCRIPTION
We were using hte zod validation data in order to pick up on any defaults passed through from zod - but that meant we were omitting the _meta on standard completions - this updates to fix that.