### PR TITLE
remove mjs extension when importing openai stream

### DIFF
--- a/src/instructor.ts
+++ b/src/instructor.ts
@@ -9,7 +9,7 @@ import {
   ReturnTypeBasedOnParams
 } from "@/types"
 import OpenAI from "openai"
-import { Stream } from "openai/streaming.mjs"
+import { Stream } from "openai/streaming"
 import { z, ZodError } from "zod"
 import ZodStream, { OAIResponseParser, OAIStream, withResponseModel, type Mode } from "zod-stream"
 import { fromZodError } from "zod-validation-error"


### PR DESCRIPTION
ran into this error when using instructor in the context of a braintrust eval 

`require() of ES Module /Users/user/code/stagehand/node_modules/.pnpm/openai@4.29.2/node_modules/openai/streaming.mjs not supported.`

looks like they build with turbo which probably doesn't like that extension being there for an es module. I see in another spot in the package you import without the extension

I tested by running the build in instructor (worked) and modifying the source in my project to remove the extension, the error didn't throw and the eval ran