### PR TITLE
Update together.md to fix example code errors

### DIFF
--- a/docs/blog/posts/together.md
+++ b/docs/blog/posts/together.md
@@ -35,39 +35,41 @@ The good news is that Anyscale employs the same OpenAI client, and its models su
 Let's explore one of the models available in Together's extensive collection!
 
 ```ts
-import Instructor from "@/instructor"
-import OpenAI from "openai"
-import { z } from "zod"
+import Instructor from "@instructor-ai/instructor";
+import OpenAI from "openai";
+import { z } from "zod";
 
-const property = z.object({
-  name: z.string(),
-  value: z.string()
-}).describe("A property defined by a name and value")
+const property = z
+  .object({
+    name: z.string(),
+    value: z.string(),
+  })
+  .describe("A property defined by a name and value");
 
 const UserSchema = z.object({
   age: z.number(),
   name: z.string(),
-  properties: z.array(property)
-})
+  properties: z.array(property),
+});
 
 const oai = new OpenAI({
-  baseUrl='https://api.together.xyz',
+  baseURL: "https://api.together.xyz",
   apiKey: process.env.TOGETHER_API_KEY ?? undefined,
-})
+});
 
 const client = Instructor({
   client: oai,
-  mode: "JSON_SCHEMA"
-})
+  mode: "JSON_SCHEMA",
+});
 
 const user = await client.chat.completions.create({
   messages: [{ role: "user", content: "Harry Potter" }],
   model: "mistralai/Mixtral-8x7B-Instruct-v0.1",
   response_model: { schema: UserSchema, name: "UserSchema" },
-  max_retries: 3
-})
+  max_retries: 3,
+});
 
-console.log(user)
+console.log(user);
 /**
  * {
   age: 17,
@@ -82,6 +84,7 @@ console.log(user)
     }
   ],
 }
+ */
  */
 ```
 

--- a/docs/blog/posts/together.md
+++ b/docs/blog/posts/together.md
@@ -35,9 +35,9 @@ The good news is that Anyscale employs the same OpenAI client, and its models su
 Let's explore one of the models available in Together's extensive collection!
 
 ```ts
-import Instructor from "@instructor-ai/instructor";
-import OpenAI from "openai";
-import { z } from "zod";
+import Instructor from "@instructor-ai/instructor"
+import OpenAI from "openai"
+import { z } from "zod"
 
 const property = z
   .object({
@@ -50,28 +50,28 @@ const UserSchema = z.object({
   age: z.number(),
   name: z.string(),
   properties: z.array(property),
-});
+})
 
 const oai = new OpenAI({
   baseURL: "https://api.together.xyz",
   apiKey: process.env.TOGETHER_API_KEY ?? undefined,
-});
+})
 
 const client = Instructor({
   client: oai,
   mode: "JSON_SCHEMA",
-});
+})
 
 const user = await client.chat.completions.create({
   messages: [{ role: "user", content: "Harry Potter" }],
   model: "mistralai/Mixtral-8x7B-Instruct-v0.1",
   response_model: { schema: UserSchema, name: "UserSchema" },
   max_retries: 3,
-});
+})
 
 console.log(user);
 /**
- * {
+ {
   age: 17,
   name: "Harry Potter",
   properties: [
@@ -84,8 +84,7 @@ console.log(user);
     }
   ],
 }
- */
- */
+ **/
 ```
 
 You can find more information about Togethers's output mode support [here](https://docs.together.ai/docs/json-mode/).


### PR DESCRIPTION
Fixed a few significant errors that prevent the code from being usable.
- corrected import string for instructor.
- `baseUrl` changed to `baseURL` to match the openai type signature.
- Also fixed typo, replacing `=` with `:` in the object definition .
- Semicolons have been added.  I think this allows for optimal portability of the example code, but I can remove if you are of a different mindset. 