### PR TITLE
Include Model Name in Completion Response

### DIFF
--- a/.changeset/blue-hats-behave.md
+++ b/.changeset/blue-hats-behave.md
@@ -1,0 +1,5 @@
+---
+"@instructor-ai/instructor": patch
+---
+
+Include Model Name in Completion Response

--- a/src/instructor.ts
+++ b/src/instructor.ts
@@ -202,6 +202,7 @@ class Instructor<C> {
           ...data,
           _meta: {
             usage: completion?.usage ?? undefined,
+            model: completion?.model ?? undefined,
             thinking: parsedCompletion?.thinking ?? undefined
           }
         }


### PR DESCRIPTION
Including model name in non-streaming completion response. Desired outputs shaped like this:
```
{
  "...": "...",
  "_meta": {
    "usage": { ... }
  },
  "thinking": "...",
  "model": "<model name>",
}
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add model name to non-streaming completion response in `Instructor` class.
> 
>   - **Behavior**:
>     - Include `model` name in non-streaming completion response in `chatCompletionStandard()` in `instructor.ts`.
>   - **Misc**:
>     - Add changeset file `blue-hats-behave.md` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor-js&utm_source=github&utm_medium=referral)<sup> for 91660c2d9222f4ec9223cf0369a0b1858bb87307. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->