### PR TITLE
fix broken link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pnpm add @instructor-ai/instructor zod openai
 ```
 
 ## Basic Usage
-To check out all the tips and tricks to prompt and extract data, check out the [documentation](https://instructor-ai.github.io/instructor-js/tips/prompting/).
+To check out all the tips and tricks to prompt and extract data, check out the [documentation](https://js.useinstructor.com/tips/prompting/).
 
 
 ```typescript


### PR DESCRIPTION
updates broken link to https://js.useinstructor.com/tips/prompting/
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link in `README.md` to correct documentation URL.
> 
>   - **Documentation**:
>     - Fix broken link in `README.md` from `https://instructor-ai.github.io/instructor-js/tips/prompting/` to `https://js.useinstructor.com/tips/prompting/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor-js&utm_source=github&utm_medium=referral)<sup> for 483b369ed9757722945c257124f9aa51ad99614e. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->